### PR TITLE
Add crate removal instructions for crates.io.

### DIFF
--- a/docs/crate-removal-procedure.md
+++ b/docs/crate-removal-procedure.md
@@ -14,6 +14,10 @@ If we get a DMCA takedown notice, here's what needs to happen:
 
       heroku run -- cargo run --bin delete-version [crate-name] [version-number]
 
+* Remove the crate or version from the index. To remove an entire crate, remove the entire crate file. For a version, remove the line corresponding to the relevant version.
+
+* Remove the crate archive(s) and readme file(s) from S3.
+
 * Invalidate the CloudFront cache – remove both the relevant readme and crate files. If in doubt, invalidate `/*` to flush everything.
 
 ## Remove relevant version(s) and/or entire crates from docs.rs

--- a/docs/crate-removal-procedure.md
+++ b/docs/crate-removal-procedure.md
@@ -8,11 +8,11 @@ If we get a DMCA takedown notice, here's what needs to happen:
 
 * Remove it from the database:
 
-      heroku run -- cargo run --bin delete-crate crate-name
+      heroku run -- cargo run --bin delete-crate [crate-name]
 	
   or
 
-      heroku run -- cargo run --bin delete-version crate-name version-number
+      heroku run -- cargo run --bin delete-version [crate-name] [version-number]
 
 * Invalidate the CloudFront cache – remove both the relevant readme and crate files. If in doubt, invalidate `/*` to flush everything.
 

--- a/docs/crate-removal-procedure.md
+++ b/docs/crate-removal-procedure.md
@@ -6,7 +6,15 @@ If we get a DMCA takedown notice, here's what needs to happen:
 
 ## Remove relevant version(s) and/or entire crates from crates.io
 
-TODO specific instructions
+* Remove it from the database:
+
+      heroku run -- cargo run --bin delete-crate crate-name
+	
+  or
+
+      heroku run -- cargo run --bin delete-version crate-name version-number
+
+* Invalidate the CloudFront cache – remove both the relevant readme and crate files. If in doubt, invalidate `/*` to flush everything.
 
 ## Remove relevant version(s) and/or entire crates from docs.rs
 


### PR DESCRIPTION
As promised in the meeting, I added a hint that we need to create a CloudFront invalidation when removing crates or versions now that rust-lang/crates.io#1871 is merged.

I also added a guess what else needs to be done, in the hope that we clarify the _actual_ steps during the review process. :)