### PR TITLE
Update docs for removing a crate from docs.rs

### DIFF
--- a/docs/crate-removal-procedure.md
+++ b/docs/crate-removal-procedure.md
@@ -29,6 +29,7 @@ to access the server and run it are:
 * docs.rs Team:
   * [@pietroalbini](https://github.com/pietroalbini)
   * [@jyn514](https://github.com/jyn514)
+  * [@onur](https://github.com/onur)
 * Infrastructure Team:
   * [@Mark-Simulacrum](https://github.com/Mark-Simulacrum)
 * People with elevated 1password access

--- a/docs/crate-removal-procedure.md
+++ b/docs/crate-removal-procedure.md
@@ -28,8 +28,8 @@ to access the server and run it are:
 
 * docs.rs Team:
   * [@pietroalbini](https://github.com/pietroalbini)
-  * [@jyn514](https://github.com/jyn514)
   * [@onur](https://github.com/onur)
+  * [@jyn514](https://github.com/jyn514)
 * Infrastructure Team:
   * [@Mark-Simulacrum](https://github.com/Mark-Simulacrum)
 * People with elevated 1password access

--- a/docs/crate-removal-procedure.md
+++ b/docs/crate-removal-procedure.md
@@ -27,9 +27,7 @@ of a crate, by running a CLI command. The people who currently have permissions
 to access the server and run it are:
 
 * docs.rs Team:
-  * [@QuietMisdreavus](https://github.com/QuietMisdreavus)
   * [@pietroalbini](https://github.com/pietroalbini)
-  * [@onur](https://github.com/onur)
   * [@jyn514](https://github.com/jyn514)
 * Infrastructure Team:
   * [@Mark-Simulacrum](https://github.com/Mark-Simulacrum)
@@ -37,4 +35,4 @@ to access the server and run it are:
 
 You can find the documentation on how to run the command [here][docsrs-howto].
 
-[docsrs-howto]: https://forge.rust-lang.org/infra/docs/docs-rs.html#removing-a-crate-from-the-website
+[docsrs-howto]: https://forge.rust-lang.org/docs-rs/maintenance.html#removing-a-crate-from-the-website


### PR DESCRIPTION
- Fix link (the old one just had a list of infra team members)
- Remove people who no longer have access to the server